### PR TITLE
Remove lingering theme reference in config template

### DIFF
--- a/examples/RailsGuides/config/kitabu.yml
+++ b/examples/RailsGuides/config/kitabu.yml
@@ -40,9 +40,5 @@ identifier:
 authors:
   - "Rails Documentation Team"
 
-# The theme that will be used for source
-# code syntax highlighting.
-theme: idle
-
 # The base URL from your source code.
 base_url: http://example.com

--- a/spec/support/mybook/config/kitabu.yml
+++ b/spec/support/mybook/config/kitabu.yml
@@ -41,10 +41,6 @@ authors:
   - "John Doe"
   - "Mary Doe"
 
-# The theme that will be used for source
-# code syntax highlighting.
-theme: idle
-
 # The base URL from your source code.
 base_url: http://example.com
 

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -40,9 +40,5 @@ identifier:
 authors:
   - "<%= @name %>"
 
-# The theme that will be used for source
-# code syntax highlighting.
-theme: mac_classic
-
 # The base URL from your source code.
 base_url: http://example.com


### PR DESCRIPTION
I asked @jstorimer on Twitter what the "theme" key was for in Kitabu's config, and received ["That's a relic from the past, should be removed. Kitabu previously used ultraviolet for syntax, now coderay or pygments."](https://twitter.com/jstorimer/status/223537757660786689)

So let's remove it. =^)
