### PR TITLE
Adds missing runtime dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,9 @@ PATH
       coderay
       eeepub-with-cover-support
       i18n
+      listen
       nokogiri
+      notifier
       rdiscount
       thor
 
@@ -19,13 +21,14 @@ GEM
       i18n (~> 0.6)
       multi_json (~> 1.0)
     awesome_print (1.0.2)
-    builder (3.1.3)
+    builder (3.1.4)
     coderay (1.0.7)
     diff-lcs (1.1.3)
     eeepub-with-cover-support (0.8.7)
       builder
       rubyzip
     i18n (0.6.1)
+    listen (0.5.3)
     method_source (0.8)
     multi_json (1.3.6)
     nokogiri (1.5.5)

--- a/kitabu.gemspec
+++ b/kitabu.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
   s.add_dependency "thor"
   s.add_dependency "eeepub-with-cover-support"
   s.add_dependency "coderay"
+  s.add_dependency "notifier"
+  s.add_dependency "listen"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "test_notifier"


### PR DESCRIPTION
Fixes issues I had after installing via `gem install kitabu`

```
[adl91macbook2:~] kitabu --version
/Users/alindeman/.rvm/rubies/ruby-1.9.3-p286/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- notifier (LoadError)

[adl91macbook2:~] kitabu --version 
/Users/alindeman/.rvm/rubies/ruby-1.9.3-p286/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in `require': cannot load such file -- listen (LoadError)
```
