### PR TITLE
Using xdg-open to preview the exported book on Linux

### DIFF
--- a/lib/kitabu/cli.rb
+++ b/lib/kitabu/cli.rb
@@ -26,7 +26,7 @@ module Kitabu
 
     desc "export [OPTIONS]", "Export e-book"
     method_option :only, :type => :string, :desc => "Can be one of: #{FORMATS.join(", ")}"
-    method_option :open, :type => :boolean, :desc => "Automatically open PDF (Mac OS X only)"
+    method_option :open, :type => :boolean, :desc => "Automatically open PDF (Preview.app for Mac OS X and xdg-open for Linux)"
 
     def export
       if options[:only] && !FORMATS.include?(options[:only])

--- a/lib/kitabu/exporter.rb
+++ b/lib/kitabu/exporter.rb
@@ -37,9 +37,14 @@ module Kitabu
         color = :green
         message = options[:auto] ? "exported!" : "** e-book has been exported"
 
-        if options[:open] && export_pdf && RUBY_PLATFORM =~ /darwin/
+        if options[:open] && export_pdf
           filepath = root_dir.join("output/#{File.basename(root_dir)}.pdf")
-          IO.popen("open -a Preview.app '#{filepath}'").close
+
+          if RUBY_PLATFORM =~ /darwin/
+            IO.popen("open -a Preview.app '#{filepath}'").close
+          elsif RUBY_PLATFORM =~ /linux/
+            Process.detach(Process.spawn("xdg-open '#{filepath}'", :out => "/dev/null"))
+          end
         end
 
         Notifier.notify(


### PR DESCRIPTION
xdg-open uses the default application to open a given
file based on mime type.
