### PR TITLE
Allow using ERB templates as content

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -140,6 +140,10 @@ and you can get the code between <tt>get_all_h2_tags</tt> using
 
 NOTE: Any named block annotation will be removed from <tt>@@@ ruby file.rb</tt> usage.
 
+=== Generating content
+
+eRb templates in the text directory will be evaluated before being processed as content. Make sure to append <tt>.erb</tt> to the regular file name (<tt>.html.erb</tt>, <tt>.markdown.erb</tt>, etc). You should probably use this sparingly, maybe to call code defined in <tt>config/helper.rb</tt>.
+
 === Markdown Processors
 
 By default, RDiscount[http://github.com/rtomayko/rdiscount/tree/master] is the Markdown processor. However, you can switch to different implementations by simply installing any of the following processors:

--- a/spec/kitabu/parser/html_spec.rb
+++ b/spec/kitabu/parser/html_spec.rb
@@ -35,7 +35,8 @@ describe Kitabu::Parser::HTML do
       relative.second.should == "02_Textile_Chapter.textile"
       relative.third.should == "03_HTML_Chapter.html"
       relative.fourth.should == "04_With_Directory"
-      relative.fifth.should be_nil
+      relative.fifth.should == "11_Markdown_Chapter_Template.md.erb"
+      relative[5].should be_nil
     end
   end
 
@@ -45,7 +46,7 @@ describe Kitabu::Parser::HTML do
     before { parser.parse }
 
     it "has several chapters" do
-      html.should have_tag("div.chapter", 4)
+      html.should have_tag("div.chapter", 5)
     end
 
     it "renders .markdown" do
@@ -54,6 +55,14 @@ describe Kitabu::Parser::HTML do
 
     it "renders .mkdn" do
       html.should have_tag("div.chapter > h2#some-chapter", "Some Chapter")
+    end
+
+    it "renders .erb" do
+      html.should have_tag("div.chapter > h2#erb", "ERB")
+    end
+
+    it "renders .erb inside directory" do
+      html.should have_tag("div > h3#yet-another-paragraph", "Yet Another Paragraph")
     end
 
     it "renders .textile" do

--- a/spec/support/mybook/text/04_With_Directory/Yet-another_Chapter.textile.erb
+++ b/spec/support/mybook/text/04_With_Directory/Yet-another_Chapter.textile.erb
@@ -1,0 +1,3 @@
+<%= "hpargaraP rehtonA teY .3h".reverse %>
+
+Yet another paragraph organized in a directory.

--- a/spec/support/mybook/text/11_Markdown_Chapter_Template.md.erb
+++ b/spec/support/mybook/text/11_Markdown_Chapter_Template.md.erb
@@ -1,0 +1,4 @@
+<%= "BRE ##".reverse %>
+
+This chapter was generated from an ERB template.
+


### PR DESCRIPTION
To include generated content in my ebooks, I have used a 2-step process: Write the generated content to files in under the text directory, then run kitabu. This makes using kitabu a little more tedious than it need be, especially when I need to interleave generated content with plain markdown. It also means I have to take care to not commit the generated content to my repo.

The simplest solution to this problem is to evaluate any ERB templates found in the text directory, and treat the results just like regular content.