### PR TITLE
Add rubyzip version to gemspec

### DIFF
--- a/kitabu.gemspec
+++ b/kitabu.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eeepub-with-cover-support"
   s.add_dependency "coderay"
   s.add_dependency "notifier"
+  s.add_dependency "rubyzip", '< 1.0.0'
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "test_notifier"


### PR DESCRIPTION
I tried kitabu with ruby 2.0.0 and with 1.9.3 and with both I got the error:

``` bash
mauro@optimus-prime:web$ kitabu check
/path/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require': cannot load such file -- zip/zip (LoadError)
    from /path/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /path/.rvm/gems/ruby-2.0.0-p247@kitabutest/gems/eeepub-with-cover-support-0.8.8/lib/eeepub/ocf.rb:1:in `<top (required)>'
    from /path/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /path/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /path/.rvm/gems/ruby-2.0.0-p247@kitabutest/gems/eeepub-with-cover-support-0.8.8/lib/eeepub.rb:3:in `<top (required)>'
    from /path/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /path/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /path/.rvm/gems/ruby-2.0.0-p247@kitabutest/gems/kitabu-1.0.4/lib/kitabu.rb:3:in `<top (required)>'
    from /path/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /path/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /path/.rvm/gems/ruby-2.0.0-p247@kitabutest/gems/kitabu-1.0.4/bin/kitabu:4:in `<top (required)>'
    from /path/.rvm/gems/ruby-2.0.0-p247@kitabutest/bin/kitabu:23:in `load'
    from /path/.rvm/gems/ruby-2.0.0-p247@kitabutest/bin/kitabu:23:in `<main>'
```

As recomended on [Rubyzip](https://github.com/rubyzip/rubyzip#important-note) I installed version `'< 1.0.0'` and now its works.

The PR is to only set a fixed version, because the kitabu is broken out of the box. :gift:
