### PR TITLE
Add Slim Templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /coverage
 .sass-cache
 *.lock
+*.gem
+*.rvmrc

--- a/kitabu.gemspec
+++ b/kitabu.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "zip-zip"
   s.add_dependency "sass"
   s.add_dependency "sass-globbing"
+  s.add_dependency "slim"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"

--- a/lib/kitabu.rb
+++ b/lib/kitabu.rb
@@ -16,6 +16,7 @@ require "yaml"
 require "cgi"
 require "erb"
 require "open3"
+require "slim"
 
 require "redcarpet"
 require "rouge"

--- a/lib/kitabu.rb
+++ b/lib/kitabu.rb
@@ -40,6 +40,7 @@ module Kitabu
   require "kitabu/generator"
   require "kitabu/cli"
   require "kitabu/markdown"
+  require "kitabu/slim"
   require "kitabu/source_list"
   require "kitabu/exporter"
   require "kitabu/exporter/base"

--- a/lib/kitabu/exporter.rb
+++ b/lib/kitabu/exporter.rb
@@ -50,7 +50,7 @@ module Kitabu
         end
 
         Notifier.notify(
-          :image   => Kitabu::ROOT.join("templates/ebook.png"),
+          :image   => Kitabu::ROOT.join("templates/ebook.png").to_s,
           :title   => "Kitabu",
           :message => "Your \"#{config[:title]}\" e-book has been exported!"
         )

--- a/lib/kitabu/exporter/epub.rb
+++ b/lib/kitabu/exporter/epub.rb
@@ -129,7 +129,7 @@ module Kitabu
       def navigation
         sections.map do |section|
           {
-            label: section.html.css(":first-child").text,
+            label: section.html.css(":first-child").text[0..20],
             content: section.filename
           }
         end

--- a/lib/kitabu/exporter/epub.rb
+++ b/lib/kitabu/exporter/epub.rb
@@ -129,7 +129,7 @@ module Kitabu
       def navigation
         sections.map do |section|
           {
-            label: section.html.css(":first-child").text[0..20],
+            label: section.html.css(":first-child").text,
             content: section.filename
           }
         end

--- a/lib/kitabu/exporter/html.rb
+++ b/lib/kitabu/exporter/html.rb
@@ -46,6 +46,8 @@ module Kitabu
       def render_file(file)
         if format(file) == :erb
           content = render_template(file, config)
+        elsif format(file) == :slim
+          content = Slim::Template.new("#{file}", {pretty:true}).render(self)
         else
           content = File.read(file)
         end
@@ -56,6 +58,8 @@ module Kitabu
       def format(file)
         if File.extname(file) == '.erb'
           :erb
+        elsif File.extname(file) == '.slim'
+          :slim
         else
           :markdown
         end

--- a/lib/kitabu/exporter/html.rb
+++ b/lib/kitabu/exporter/html.rb
@@ -47,7 +47,7 @@ module Kitabu
         if format(file) == :erb
           content = render_template(file, config)
         elsif format(file) == :slim
-          content = Slim::Template.new("#{file}", {pretty:true}).render(self)
+          content = Kitabu::ToSlim.render(file)
         else
           content = File.read(file)
         end

--- a/lib/kitabu/slim.rb
+++ b/lib/kitabu/slim.rb
@@ -1,0 +1,8 @@
+module Kitabu
+  module ToSlim
+
+    def self.render(file)
+      Slim::Template.new("#{file}", {pretty:true}).render(self)
+    end
+  end
+end

--- a/lib/kitabu/source_list.rb
+++ b/lib/kitabu/source_list.rb
@@ -10,7 +10,7 @@ module Kitabu
 
     # List of recognized extensions.
     #
-    EXTENSIONS = %w[md erb]
+    EXTENSIONS = %w[md erb slim]
 
     attr_reader :root_dir
     attr_reader :source

--- a/lib/kitabu/toc/epub.rb
+++ b/lib/kitabu/toc/epub.rb
@@ -27,7 +27,7 @@ module Kitabu
                 <ul>
                   <% navigation.each do |nav| %>
                     <li>
-                      <a href="<%= nav[:content] %>"><%= nav[:label] %></a>
+                      <a href="<%= nav[:content] %>"><%= nav[:label][30] %> </a>
                     </li>
                   <% end %>
                 </ul>

--- a/lib/kitabu/toc/epub.rb
+++ b/lib/kitabu/toc/epub.rb
@@ -27,7 +27,7 @@ module Kitabu
                 <ul>
                   <% navigation.each do |nav| %>
                     <li>
-                      <a href="<%= nav[:content] %>"><%= nav[:label][30] %> </a>
+                      <a href="<%= nav[:content] %>"><%= nav[:label]%></a>
                     </li>
                   <% end %>
                 </ul>

--- a/lib/kitabu/toc/epub.rb
+++ b/lib/kitabu/toc/epub.rb
@@ -27,7 +27,7 @@ module Kitabu
                 <ul>
                   <% navigation.each do |nav| %>
                     <li>
-                      <a href="<%= nav[:content] %>"><%= nav[:label] %></a>
+                      <a href="<%= nav[:content] %>"><%= nav[:label][0..20].gsub(/\s\w+\s*$/,'...') %></a>
                     </li>
                   <% end %>
                 </ul>

--- a/lib/kitabu/toc/epub.rb
+++ b/lib/kitabu/toc/epub.rb
@@ -27,7 +27,7 @@ module Kitabu
                 <ul>
                   <% navigation.each do |nav| %>
                     <li>
-                      <a href="<%= nav[:content] %>"><%= nav[:label][0..20].gsub(/\s\w+\s*$/,'...') %></a>
+                      <a href="<%= nav[:content] %>"><%= nav[:label] %></a>
                     </li>
                   <% end %>
                 </ul>

--- a/lib/kitabu/version.rb
+++ b/lib/kitabu/version.rb
@@ -2,7 +2,7 @@ module Kitabu
   module Version
     MAJOR = 2
     MINOR = 0
-    PATCH = 4
+    PATCH = 5
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}"
   end
 end

--- a/spec/kitabu/exporter/html_spec.rb
+++ b/spec/kitabu/exporter/html_spec.rb
@@ -24,7 +24,7 @@ describe Kitabu::Exporter::HTML do
     end
 
     it "has several chapters" do
-      expect(html).to have_tag("div.chapter", 3)
+      expect(html).to have_tag("div.chapter", 4)
     end
 
     it "uses config file" do

--- a/spec/kitabu/source_list_spec.rb
+++ b/spec/kitabu/source_list_spec.rb
@@ -35,7 +35,8 @@ describe Kitabu::SourceList do
       expect(relative.first).to eq("01_Markdown_Chapter.md")
       expect(relative.second).to eq("02_ERB_Chapter.md.erb")
       expect(relative.third).to eq("03_With_Directory")
-      expect(relative.fourth).to be_nil
+      expect(relative.fourth).to eq("04_Slim_Content.md.slim")
+      expect(relative[5]).to be_nil
     end
   end
 end

--- a/spec/support/mybook/text/04_Slim_Content.md.slim
+++ b/spec/support/mybook/text/04_Slim_Content.md.slim
@@ -1,1 +1,2 @@
-= 'BRE ##'.reverse
+h2 Slim Test
+p Slim simple sample

--- a/spec/support/mybook/text/04_Slim_Content.md.slim
+++ b/spec/support/mybook/text/04_Slim_Content.md.slim
@@ -1,0 +1,1 @@
+= 'BRE ##'.reverse

--- a/templates/text/06_Sample_Slim_File.md.slim
+++ b/templates/text/06_Sample_Slim_File.md.slim
@@ -1,0 +1,3 @@
+h2 Sample Slim File
+p Boo
+p.text Foo

--- a/templates/text/06_Sample_Slim_File.md.slim
+++ b/templates/text/06_Sample_Slim_File.md.slim
@@ -1,3 +1,10 @@
-h2 Sample Slim File
-p Boo
-p.text Foo
+h2 Using Slim syntax
+blockquote
+  |h2 Markup examples
+  br
+  br
+  |#content
+  br
+  |&nbsp;&nbsp;&nbsp;&nbsp; p This example shows you how a basic Slim file looks like.
+
+p: a href="http://slim-lang.com/" About Slim


### PR DESCRIPTION
Allow using Slim templates as content.
 
[About Slim](http://slim-lang.com/index.html)
Slim is a template language whose goal is reduce the syntax to the essential parts without becoming cryptic.

The initial design of Slim is what you see on the home page. It started as an exercise to see how much could be removed from a standard html template (<, >, closing tags, etc...). As more people took an interest in Slim, the functionality grew and so did the flexibility of the syntax.

