### PR TITLE
Updates Kitabu to use Rouge 2.0

### DIFF
--- a/kitabu.gemspec
+++ b/kitabu.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "thor"
   s.add_dependency "redcarpet"
   s.add_dependency "eeepub-with-cover-support"
-  s.add_dependency "rouge"
+  s.add_dependency "rouge", "~> 2.0"
   s.add_dependency "notifier"
   s.add_dependency "rubyzip"
   s.add_dependency "zip-zip"

--- a/lib/kitabu/extensions/rouge.rb
+++ b/lib/kitabu/extensions/rouge.rb
@@ -3,7 +3,7 @@ module Rouge
     module Redcarpet
       def rouge_formatter(lexer)
         options = lexer.respond_to?(:options) ? lexer.options : {}
-        Formatters::HTML.new({css_class: "highlight #{lexer.tag}"}.merge(options))
+        Formatters::HTMLLegacy.new({css_class: "highlight #{lexer.tag}"}.merge(options))
       end
     end
   end


### PR DESCRIPTION
Kitabu was not working with newer versions of Rouge (2+ versions).

This PR fixes this.