### PR TITLE
Ensure correct numerical sorting of TOC when chapters exceed 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Remove inline alignment from tables.
 - Render `<figure>` for images with title.
 - Render abbreviations with (e.g. `*[CSS]: Cascading Style Sheets`).
+- Ensure correct numerical sorting of TOC when chapters exceed 9
 
 ## v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Remove inline alignment from tables.
 - Render `<figure>` for images with title.
 - Render abbreviations with (e.g. `*[CSS]: Cascading Style Sheets`).
-- Ensure correct numerical sorting of TOC when chapters exceed 9
+- Ensure correct numerical sorting of TOC when there are more than 10 chapters
 
 ## v3.1.0
 

--- a/lib/kitabu/exporter/epub.rb
+++ b/lib/kitabu/exporter/epub.rb
@@ -8,13 +8,14 @@ module Kitabu
 
       def sections
         @sections ||=
-          html.css(SECTION_SELECTOR).each_with_index.map do |chapter, index|
+          html.css(SECTION_SELECTOR).each.with_index(1).map do |chapter, index|
             html = Nokogiri::HTML5.fragment(chapter.inner_html)
+            section_number = index.to_s.rjust(2, '0')
 
             OpenStruct.new(
               index:,
-              filename: "section_#{index}.html",
-              filepath: tmp_dir.join("section_#{index}.html").to_s,
+              filename: "section_#{section_number}.html",
+              filepath: tmp_dir.join("section_#{section_number}.html").to_s,
               html:
             )
           end

--- a/spec/kitabu/exporter/epub_spec.rb
+++ b/spec/kitabu/exporter/epub_spec.rb
@@ -5,10 +5,21 @@ require "spec_helper"
 describe Kitabu::Exporter::Epub do
   let(:root) { SPECDIR.join("support/mybook") }
 
-  it "generates e-pub" do
+  before do
     Kitabu::Exporter::HTML.export(root)
     Kitabu::Exporter::Epub.export(root)
+  end
 
+  it "generates e-pub" do
     expect(root.join("output/mybook.epub")).to be_file
+  end
+
+  it "adds leading zero to 1 digit number" do
+    sections = root.join("output/epub").glob("section*.{xhtml,html}")
+    sections = sections.map do |path|
+      path.to_s.split("/").last
+    end
+    expected = 1.upto(12).map {|i| "section_#{i.to_s.rjust(2, '0')}.html" }
+    expect(sections).to eq(expected)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,19 +45,19 @@ RSpec.configure do |config|
     linux: false
   )
 
-  cleaner = proc do
-    [
-      TMPDIR,
-      SPECDIR.join("support/mybook/output")
-    ].each do |i|
-      FileUtils.rm_rf(i)
-    end
+  # cleaner = proc do
+  #   [
+  #     TMPDIR,
+  #     SPECDIR.join("support/mybook/output")
+  #   ].each do |i|
+  #     FileUtils.rm_rf(i)
+  #   end
 
-    Dir.chdir File.expand_path("..", __dir__)
-  end
+  #   Dir.chdir File.expand_path("..", __dir__)
+  # end
 
-  config.before(&cleaner)
-  config.after(&cleaner)
+  # config.before(&cleaner)
+  # config.after(&cleaner)
   config.before { FileUtils.mkdir_p(TMPDIR) }
 
   config.before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,19 +45,19 @@ RSpec.configure do |config|
     linux: false
   )
 
-  # cleaner = proc do
-  #   [
-  #     TMPDIR,
-  #     SPECDIR.join("support/mybook/output")
-  #   ].each do |i|
-  #     FileUtils.rm_rf(i)
-  #   end
+  cleaner = proc do
+    [
+      TMPDIR,
+      SPECDIR.join("support/mybook/output")
+    ].each do |i|
+      FileUtils.rm_rf(i)
+    end
 
-  #   Dir.chdir File.expand_path("..", __dir__)
-  # end
+    Dir.chdir File.expand_path("..", __dir__)
+  end
 
-  # config.before(&cleaner)
-  # config.after(&cleaner)
+  config.before(&cleaner)
+  config.after(&cleaner)
   config.before { FileUtils.mkdir_p(TMPDIR) }
 
   config.before do

--- a/spec/support/mybook/text/05_Chapter 5.md
+++ b/spec/support/mybook/text/05_Chapter 5.md
@@ -1,0 +1,3 @@
+## Chapter 5
+
+This is Chapter 5

--- a/spec/support/mybook/text/06_Chapter 6.md
+++ b/spec/support/mybook/text/06_Chapter 6.md
@@ -1,0 +1,3 @@
+## Chapter 6
+
+This is Chapter 6

--- a/spec/support/mybook/text/07_Chapter 7.md
+++ b/spec/support/mybook/text/07_Chapter 7.md
@@ -1,0 +1,3 @@
+## Chapter 7
+
+This is Chapter 7

--- a/spec/support/mybook/text/08_Chapter 8.md
+++ b/spec/support/mybook/text/08_Chapter 8.md
@@ -1,0 +1,3 @@
+## Chapter 8
+
+This is Chapter 8

--- a/spec/support/mybook/text/09_Chapter 9.md
+++ b/spec/support/mybook/text/09_Chapter 9.md
@@ -1,0 +1,3 @@
+## Chapter 9
+
+This is Chapter 9

--- a/spec/support/mybook/text/10_Chapter 10.md
+++ b/spec/support/mybook/text/10_Chapter 10.md
@@ -1,0 +1,3 @@
+## Chapter 10
+
+This is Chapter 10

--- a/spec/support/mybook/text/11_Chapter 11.md
+++ b/spec/support/mybook/text/11_Chapter 11.md
@@ -1,0 +1,3 @@
+## Chapter 11
+
+This is Chapter 11


### PR DESCRIPTION
This PR solves the order of the TOC when there are more than 10 chapters, so the generated HTML would be like this:

```
section_0.html section_1.html section_10.html section_2.html section_3.html ...
```

The `write_toc!` depends on the order of the section's HTML, thus wrong ordering results in an invalid ToC ordering.

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

- Make the section number consistent by adding one leading zero if it's below 10
- Start the section number from 1 instead of 0

### Why

It's a bug that needs to be solved.

### Known limitations

N/A
